### PR TITLE
Correct ignored egress port override in ec2 example

### DIFF
--- a/doc_source/mesh-getting-started-ec2.md
+++ b/doc_source/mesh-getting-started-ec2.md
@@ -75,7 +75,7 @@ AWS App Mesh is a service mesh based on the [Envoy](https://www.envoyproxy.io/) 
    if [ -z "$APPMESH_EGRESS_IGNORED_PORTS" ]; then
        APPMESH_EGRESS_IGNORED_PORTS="22"
    else
-       APPMESH_EGRESS_IGNORED_PORTS=",22"
+       APPMESH_EGRESS_IGNORED_PORTS="$APPMESH_EGRESS_IGNORED_PORTS,22"
    fi
    
    #

--- a/doc_source/mesh-getting-started-k8s.md
+++ b/doc_source/mesh-getting-started-k8s.md
@@ -20,7 +20,7 @@ App Mesh is a service mesh based on the [Envoy](https://www.envoyproxy.io/) prox
 
 App Mesh vends the following custom container images that you must add to your Kubernetes pod specifications\.
 + App Mesh Envoy container image: `111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.9.0.0-prod`
-+ App Mesh proxy route manager: `111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:latest`
++ App Mesh proxy route manager: `111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v2`
 
 The following is an example Kubernetes pod specification that you can merge with your existing application\. Substitute your mesh name and virtual node name for the `APPMESH_VIRTUAL_NODE_NAME` value, and a list of ports that your application listens on for the `APPMESH_APP_PORTS` value\. Substitute the Amazon EC2 instance AWS Region for the `AWS_REGION` value\.
 
@@ -42,7 +42,7 @@ spec:
           value: "aws_region_name"
   initContainers:
     - name: proxyinit
-      image: 111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:latest
+      image: 111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v2
       securityContext:
         capabilities:
           add: 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-app-mesh-roadmap/issues/62

*Description of changes:*

The current example script for EC2 has an error in the example proxy route manager script. This change allows the customer to provide a custom list of ignored egress ports for Envoy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
