### PR TITLE
Include a list of service quota defaults

### DIFF
--- a/doc_source/service-quotas.md
+++ b/doc_source/service-quotas.md
@@ -2,9 +2,8 @@
 
 AWS App Mesh has integrated with Service Quotas, an AWS service that enables you to view and manage your quotas from a central location\. Service quotas are also referred to as limits\. For more information, see [What Is Service Quotas?](https://docs.aws.amazon.com/servicequotas/latest/userguide/intro.html) in the *Service Quotas User Guide*\.
 
-Service Quotas makes it easy to look up the value of all of the App Mesh service quotas\.
-
-**To view App Mesh service quotas \(AWS Management Console\)**
+## View AWS App Mesh service quotas<a name="view-service-quotas"></a>
+To view App Mesh service quotas in the AWS Management Console:
 
 1. Open the Service Quotas console at [https://console\.aws\.amazon\.com/servicequotas/](https://console.aws.amazon.com/servicequotas/)\.
 
@@ -16,4 +15,25 @@ Service Quotas makes it easy to look up the value of all of the App Mesh service
 
 1. To view additional information about a service quota, such as the description, choose the quota name\.
 
+## Request an AWS App Mesh service quota increase<a name="increase-service-quota"></a>
 To request a quota increase, see [Requesting a Quota Increase](https://docs.aws.amazon.com/servicequotas/latest/userguide/request-increase.html) in the *Service Quotas User Guide*\.
+
+## Default AWS App Mesh service quotas<a name="default-service-quotas"></a>
+
+The following table provides the default AWS App Mesh quotas for an AWS account that can be changed\.
+
+| Resource | Default Quota | 
+| --- | --- | 
+| Maximum number of meshes \(per region, per account\) | 15 | 
+| Maximum number of virtual services per mesh | 200 | 
+| Maximum number of virtual nodes per mesh | 200 | 
+| Maximum number of backends per virtual node | 50 | 
+| Maximum number of connected Envoys per virtual node | 10 | 
+| Maximum number of virtual routers per mesh | 200 | 
+| Maximum number of routes per virtual router | 50 | 
+
+The following table provides quotas for AWS App Mesh that cannot be changed\.
+
+| Resource | Default Quota | 
+| --- | --- | 
+| Maximum number of weighted targets per route | 10 | 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Include a list of service quota defaults in public docs, so that a customer does not have to log into the AWS web console in order to see these default values. Most of the text and layout was copied from another project, https://github.com/awsdocs/amazon-eks-user-guide/blob/master/doc_source/service-quotas.md, so hopefully it passes muster!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
