### PR TITLE
Specify Root PCA requirement for TLS client policies

### DIFF
--- a/doc_source/tls.md
+++ b/doc_source/tls.md
@@ -22,9 +22,9 @@ For additional requirements, select the issuer of the certificate that you're us
 
 ### ACM PCA<a name="certificate-pca"></a>
 
-The certificate must be stored in ACM in the same Region and AWS Account, as the virtual node that will use the certificate\. If you don't have an ACM Private CA, then you must [create one](https://docs.aws.amazon.com/acm-pca/latest/userguide/PcaCreateCa.html) before you can request a certificate from it\. For more information about requesting a certificate from an existing ACM PCA using ACM, see [Request a Private Certificate](https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-request-private.html)\. The certificate cannot be a public certificate\.
+The certificate or certificate authority must be stored in ACM in the same Region and AWS Account, as the mesh endpoint that will use the certificate\. If you don't have an ACM Private CA, then you must [create one](https://docs.aws.amazon.com/acm-pca/latest/userguide/PcaCreateCa.html) before you can request a certificate from it\. For more information about requesting a certificate from an existing ACM PCA using ACM, see [Request a Private Certificate](https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-request-private.html)\. The certificate cannot be a public certificate\.
 
-The Private CAs you use for TLS client policies must be Root CAs and also stored in the same Region and AWS Account as the virtual node that will use the CA\.
+The Private CAs you use for TLS client policies must be Root CAs\.
 
 To configure a virtual node with certificates and CAs from ACM PCA, the principal \(such as a user or role\) that you use to call App Mesh must have the following IAM permissions: 
 + For any certificates that you add to a listener's TLS configuration, the principal must have the `acm:DescribeCertificate` permission\.

--- a/doc_source/tls.md
+++ b/doc_source/tls.md
@@ -22,7 +22,9 @@ For additional requirements, select the issuer of the certificate that you're us
 
 ### ACM PCA<a name="certificate-pca"></a>
 
-The certificate must be stored in ACM in the same Region and IAM user, as the mesh endpoint that will use the certificate\. If you don't have an ACM Private CA, then you must [create one](https://docs.aws.amazon.com/acm-pca/latest/userguide/PcaCreateCa.html) before you can request a certificate from it\. For more information about requesting a certificate from an existing ACM PCA using ACM, see [Request a Private Certificate](https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-request-private.html)\. The certificate cannot be a public certificate\.
+The certificate must be stored in ACM in the same Region and AWS Account, as the virtual node that will use the certificate\. If you don't have an ACM Private CA, then you must [create one](https://docs.aws.amazon.com/acm-pca/latest/userguide/PcaCreateCa.html) before you can request a certificate from it\. For more information about requesting a certificate from an existing ACM PCA using ACM, see [Request a Private Certificate](https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-request-private.html)\. The certificate cannot be a public certificate\.
+
+The Private CAs you use for TLS client policies must be Root CAs and also stored in the same Region and AWS Account as the virtual node that will use the CA\.
 
 To configure a virtual node with certificates and CAs from ACM PCA, the principal \(such as a user or role\) that you use to call App Mesh must have the following IAM permissions: 
 + For any certificates that you add to a listener's TLS configuration, the principal must have the `acm:DescribeCertificate` permission\.


### PR DESCRIPTION
*Description of changes:*

A one-line addition to specify the requirement to use Root CAs. We probably also want to elaborate on _why_ this is required, but I don't know which section is appropriate, and that'll take a slightly more involved write-up.

Also changed mention of `mesh endpoint` to `virtual node` in this section as I think it's more clear on configuration. And changed `IAM User` to `AWS Account` as the phrase `The certificate must be stored in the same IAM user` is I think misleading?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
