### PR TITLE
Highlight cross-account Virtual Gateway

### DIFF
--- a/doc_source/gateway-routes.md
+++ b/doc_source/gateway-routes.md
@@ -14,7 +14,9 @@ To create a gateway route using the AWS CLI version 1\.18\.116 or later, see the
 
 1. Choose **Virtual gateways** in the left navigation\.
 
-1. Choose the virtual gateway that you want to associate a new gateway route with\. If none are listed, then you need to [create a virtual gateway](virtual_gateways.md#create-virtual-gateway) first\. You can only create a gateway route for a virtual gateway that your account is listed as the **Resource owner** of\.
+1. Choose the virtual gateway that you want to associate a new gateway route with\. If none are listed, then you need to [create a virtual gateway](virtual_gateways.md#create-virtual-gateway) first\.
+**Important**
+You can only create a gateway route for a virtual gateway that your account is listed as the **Resource owner** of\.
 
 1. In the **Gateway routes** table, choose **Create gateway route**\.
 


### PR DESCRIPTION
Make cross-account Virtual Gateway limitations clear

*Issue #, if available:*

*Description of changes:*
I discovered that I can't use Virtual Gateways in another account that shares the mesh through an error message on attempt. It would have been useful if I had not missed this in the docs. Alternatively, this could go in [Working with shared meshes](https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html) Happy for all feedback as this is my first attempt at changing aws docs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
