### PR TITLE
Remove incorrect wildcard chars from an example in troubleshooting kubernetes

### DIFF
--- a/doc_source/troubleshooting-kubernetes.md
+++ b/doc_source/troubleshooting-kubernetes.md
@@ -37,7 +37,7 @@ spec:
   template:
     metadata:
       annotations:
-        *appmesh**.k8s.aws/mesh: my-mesh
+        appmesh.k8s.aws/mesh: my-mesh
         appmesh.k8s.aws/virtualNode:my-virtual-node
 ...
 ```


### PR DESCRIPTION
*Description of changes:*

I think the following example in the following document has incorrect wildcard chars.

https://docs.aws.amazon.com/app-mesh/latest/userguide/troubleshooting-kubernetes.html

```
      annotations:
        *appmesh**.k8s.aws/mesh: my-mesh
        appmesh.k8s.aws/virtualNode:my-virtual-node
```

I believe the above appmesh does not require wildcards in the config.
So, I fixed the original document, troubleshooting-kubernetes.md, in this pull request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
