### PR TITLE
Backend for serviceA is not configured properly

### DIFF
--- a/doc_source/getting-started-ecs.md
+++ b/doc_source/getting-started-ecs.md
@@ -277,7 +277,7 @@ To complete the scenario, you need to:
 
 1. Choose **Create virtual node** again\. Enter **serviceA** for the **Virtual node name**\. For **Service discovery method**, choose **DNS**, and for **DNS hostname**, enter **servicea\.apps\.local**\.
 
-1. For **Enter a virtual service name** under **New backend**, enter **servicea\.apps\.local**\.
+1. For **Enter a virtual service name** under **New backend**, enter **serviceb\.apps\.local**\.
 
 1. Under **Listener configuration**, choose **http2** for **Protocol**, enter **80** for **Port**, and then choose **Create virtual node**\.
 


### PR DESCRIPTION
Backend for serviceA is not configured properly. It has been configured as serviceA, when it should be serviceB.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
