### PR TITLE
updated tags sharing.md

### DIFF
--- a/doc_source/sharing.md
+++ b/doc_source/sharing.md
@@ -76,6 +76,9 @@ Owners and consumers can identify shared meshes and mesh resources using the Ama
 **To identify a shared mesh using the AWS CLI**  
 Use the `aws appmesh list resource` command, such as `aws appmesh [list\-meshes](https://docs.aws.amazon.com/cli/latest/reference/appmesh/list-meshes.html)`\. The command returns the meshes that you own and the meshes that are shared with you\. The `meshOwner` property shows the AWS account ID of the `meshOwner` and the `resourceOwner` property shows the AWS account ID of the resource owner\. Any command run against any mesh resource returns these properties\.
 
+**Tags of a shared mesh** 
+User-defined tags that you attach to a shared mesh are available only to your AWS account and not to the other accounts that the mesh is shared with. 
+
 ## Billing and metering<a name="sharing-billing"></a>
 
 There are no charges for sharing a mesh\.


### PR DESCRIPTION
Added information about listing tags of a shared mesh and the limitation concern

*Issue #, if available:*
Cannot list tags of mesh shared with account 

*Description of changes:*
There is no information on AppMesh that states that tags of shared mesh cannot be shared. 
It is better to add this information on this page.

Steps to reproduce below:
```
aws appmesh list-tags-for-resource \
    --resource-arn ${APPMESH_DEFAULT}                 
...
output:
An error occurred (AccessDeniedException) when calling the ListTagsForResource operation: arn:aws:appmesh:eu-west-1:111111111111:mesh/default is an invalid ARN. Invalid account id in the ARN provided : 111111111111
```
1. ARN is valid
2. Account ID is valid

The error message says arn is invalid because it expects the Account ID to be the ID of the present IAM entity making the API call.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
